### PR TITLE
fix(int33): restore original DOSBox mickey formula in getRelMickey

### DIFF
--- a/native/jsdos/jsdos-mouse.cpp
+++ b/native/jsdos/jsdos-mouse.cpp
@@ -180,11 +180,32 @@ mickey getRelMickey(float prevCol, float prevRow,
   auto dCol = col - prevCol;
   auto dRow = row - prevRow;
 
-  auto pxPerCol = surfaceWidth / (float) (mouse.max_x - mouse.min_x);
-  auto pxPerRow = surfaceHeight / (float) (mouse.max_y - mouse.min_y);
-
-  int mickey_x = (int) round(dCol * pxPerCol * mouse.mickeysPerPixel_x);
-  int mickey_y = (int) round(dRow * pxPerRow * mouse.mickeysPerPixel_y / 2); // why div 2?
+  // Match the original DOSBox mickey formula: mickey = delta *
+  // mickeysPerPixel, applied directly to the absolute col/row delta.
+  //
+  // The previous version multiplied by `pxPerCol = surfaceWidth / max_x`
+  // (≈ 0.5 for VGA mode 13h, since INT 33h uses a doubled-X range 0..639
+  // over a 320-pixel screen) and also divided the Y mickey by 2 (the
+  // `// why div 2?` comment). Together these halve the mickey rate that
+  // DOS games see via INT 33h fn 0x0B / INT 74 callbacks.
+  //
+  // Games that read cursor position only through the mickey stream (e.g.
+  // Ultima Underworld 1/2, whose UW.EXE reads `mov ax,0Bh;int 33h` then
+  // `imul bx=100; idiv [200]` to convert mickeys to game pixels) get
+  // cursor motion at ½ the expected rate. Restoring the original DOSBox
+  // formula fixes UW1/UW2 cursor tracking.
+  //
+  // Also carry a per-axis fractional residual so sub-mickey motions
+  // (e.g. dCol=0.5 in cumulative pass-through) don't vanish to int
+  // rounding. Without this, slow drags stutter or stall.
+  static float mickey_x_residual = 0.0f;
+  static float mickey_y_residual = 0.0f;
+  float mickey_x_f = dCol * mouse.mickeysPerPixel_x + mickey_x_residual;
+  float mickey_y_f = dRow * mouse.mickeysPerPixel_y + mickey_y_residual;
+  int mickey_x = (int) round(mickey_x_f);
+  int mickey_y = (int) round(mickey_y_f);
+  mickey_x_residual = mickey_x_f - (float) mickey_x;
+  mickey_y_residual = mickey_y_f - (float) mickey_y;
 
   if (mickey_x >= 32768.0)  {
     mickey_x -= 65536.0;
@@ -201,8 +222,9 @@ mickey getRelMickey(float prevCol, float prevRow,
   return {
     .mickey_x = mickey_x,
     .mickey_y = mickey_y,
-    .col = prevCol + ((float) mickey_x / pxPerCol / mouse.mickeysPerPixel_x),
-    .row = prevRow + ((float) mickey_y / pxPerRow / mouse.mickeysPerPixel_y * 2)
+    // Invert the mickey formula: dCol = mickey / mickeysPerPixel_x.
+    .col = prevCol + ((float) mickey_x / mouse.mickeysPerPixel_x),
+    .row = prevRow + ((float) mickey_y / mouse.mickeysPerPixel_y),
   };
 }
 

--- a/native/jsdos/jsdos-mouse.cpp
+++ b/native/jsdos/jsdos-mouse.cpp
@@ -177,9 +177,17 @@ mickey getRelMickey(float prevCol, float prevRow,
     if (!mouse.in_UIR) {
       mickeyRelSyncTries--;
     }
+    // Return a *zero* mickey delta and the current absolute col/row.
+    // Previously this returned -(max - min) as a sentinel which games
+    // using INT 33h fn 0x0B (e.g. Ultima Underworld) accumulate into
+    // their own cursor position tracker — one big negative delta per
+    // poll rapidly walked UW's cursor off-screen even though mouse.col
+    // / mouse.row were correct for fn 0x03. Zero delta keeps fn 0x0B
+    // consumers in sync while still clearing the internal mickey
+    // accumulator that the sync is there to reset.
     return {
-        .mickey_x = -(mouse.max_x - mouse.min_x),
-        .mickey_y = -(mouse.max_y - mouse.min_y),
+        .mickey_x = 0,
+        .mickey_y = 0,
         .col = mouse.col,
         .row = mouse.row,
     };

--- a/native/jsdos/jsdos-mouse.cpp
+++ b/native/jsdos/jsdos-mouse.cpp
@@ -162,8 +162,16 @@ mickey getRelMickey(float prevCol, float prevRow,
   }
 
   while (mickeyRelSyncTries) {
-    mouse.col = 0;
-    mouse.row = 0;
+    // The sync pass exists to clear accumulated RELATIVE mickey drift when
+    // the host cursor regains focus — it must not touch the ABSOLUTE cursor
+    // position (mouse.col / mouse.row), which is what INT 33h fn 0x03
+    // returns to DOS games as POS_X / POS_Y. Previously this loop zeroed
+    // mouse.col / mouse.row, which combined with the fact that every
+    // wc-mouse-sync message re-arms mickeyRelSyncTries meant that bridges
+    // which sync on every event (e.g. abedegno/dos-mcp) kept the cursor
+    // pinned at (0, 0) permanently — fn 0x03 reported POS_X=POS_Y=0 even
+    // while absolute updates through Mouse_CursorMoved were landing
+    // correctly in mouse.col / mouse.row.
     mouse.mickeyCol = 0;
     mouse.mickeyRow = 0;
     if (!mouse.in_UIR) {
@@ -172,8 +180,8 @@ mickey getRelMickey(float prevCol, float prevRow,
     return {
         .mickey_x = -(mouse.max_x - mouse.min_x),
         .mickey_y = -(mouse.max_y - mouse.min_y),
-        .col = 0,
-        .row = 0,
+        .col = mouse.col,
+        .row = mouse.row,
     };
   }
 


### PR DESCRIPTION
### Summary

`getRelMickey` in `native/jsdos/jsdos-mouse.cpp` has two factors that don't appear in upstream DOSBox and that together halve the mickey stream delivered to DOS programs via **INT 33h fn 0x0B (Read Motion Data)** and the **INT 74 mouse callback**:

```cpp
auto pxPerCol = surfaceWidth / (float) (mouse.max_x - mouse.min_x);   // ≈ 0.5 for VGA mode 13h
int mickey_x = round(dCol * pxPerCol * mouse.mickeysPerPixel_x);
int mickey_y = round(dRow * pxPerRow * mouse.mickeysPerPixel_y / 2);  // ``// why div 2?``
```

Upstream DOSBox uses the simpler `mickey += delta * mickeysPerPixel`. The `pxPerCol` factor is ≈ 0.5 for standard VGA mode 13h because INT 33h reports X over a doubled 0..639 range while the rendered screen is 320 pixels wide — so every mickey we report is half what upstream DOSBox would report. The `/2` on Y is flagged as suspect by the very comment next to it.

Any DOS game that relies on the mickey stream (most mouse-aware games from the Microsoft-mouse-driver era) therefore sees cursor motion at roughly ½ the expected rate in js-dos, while the same game run on native DOSBox tracks 1:1.

### Repro

Ultima Underworld I/II is a clean case. `UW.EXE` reads cursor motion exclusively through fn 0x0B, never fn 0x03 (confirmed by disassembling the three `int 33h` sites in the binary):

- `0x22c68` — init: `mov ax,0; int 33h`, then stores 200 into `[0x360]` and `[0x362]`.
- `0x22c87` — tick: `mov ax,0Bh; int 33h`, then calls the helper at `0x22c98` on both `mickey_x` (from CX) and `mickey_y` (from DX).
- `0x22ca3` — button read only: `mov ax,3; int 33h; and ax, 3; ret` (POS_X / POS_Y are discarded).

Helper at `0x22c98` is:

```asm
mov bx, 64h        ; BX = 100
imul bx            ; DX:AX = mickey * 100
idiv [0x360]       ; AX   = mickey * 100 / 200  =  mickey / 2
xchg bx, ax
ret
```

UW1's cursor-per-pixel rate is therefore exactly `mickey / 2`. With the current js-dos rate (half-mickey per dCol), UW1's crosshair travels ≈ ½ the width of the viewport for a full host-mouse drag across the canvas. With the formula restored to upstream, it tracks 1:1 — verified by driving UW1 inside a local build.

### Fix

Drop the `pxPerCol`/`pxPerRow` and `/2` factors. Use the original DOSBox formula, applied directly to the absolute col/row deltas, and invert it the same way for `rel.col`/`rel.row`. Also carry a per-axis fractional residual across calls so sub-mickey motions (e.g. `dCol = 0.5` from a slow incremental pass-through) don't round to zero and leave `mouse.mickeyCol` stuck behind `mouse.col` — which was causing a secondary bug where slow drags stutter or stall.

### Compatibility note

This doubles the mickey rate delivered by fn 0x0B / INT 74 vs previous js-dos releases. If anyone had calibrated their integration around the halved rate, their game will now feel twice as fast. The new rate matches native DOSBox, so any game that works on native DOSBox will work here. But if you'd prefer to gate this behind a flag rather than change default behavior, happy to reshape it that way.

Paths not affected:
- fn 0x03 (absolute position) — reads `mouse.col` / `mouse.row` directly, unchanged.
- Pointer-locked / relative mode — separate code path in `server_mouse_moved`, unchanged.
- Games that set their own mickey rate via fn 0x0F — `mickeysPerPixel_x/y` is still multiplied in, so game-set rates still apply.

### Related issues

Plausibly the root cause (or a contributor) for:
- #316 — "Mouse works very slowly in WarCraft II"
- #351 — "mouse cursor doesn't move on all of the screen (jsdos v8 bug)"
- #313 — "inaccurate mouse positioning" in DOS games